### PR TITLE
Ensure wishlist contains only unique product IDs in PUT request

### DIFF
--- a/app/api/user/wishlist/route.ts
+++ b/app/api/user/wishlist/route.ts
@@ -64,10 +64,15 @@ export async function PUT(request: NextRequest) {
     
     const { wishlist } = await request.json();
     
+    // Ensure wishlist contains only unique product IDs
+    const uniqueWishlist = Array.isArray(wishlist) 
+      ? [...new Set(wishlist)] 
+      : [];
+    
     await connectDB();
     const user = await User.findByIdAndUpdate(
       authResult.user?.id,
-      { $set: { wishlist } },
+      { $set: { wishlist: uniqueWishlist } },
       { new: true }
     );
     


### PR DESCRIPTION
This pull request includes an important change to the `app/api/user/wishlist/route.ts` file. The change ensures that the wishlist contains only unique product IDs before updating the user's wishlist in the database.

Key change:

* [`app/api/user/wishlist/route.ts`](diffhunk://#diff-48cb52f6b2b3aaa03ec22dcf5b04608a84b415f69606b5c2c3efaf498b10b268R67-R75): Added logic to filter the wishlist to include only unique product IDs before updating the user's wishlist in the database.