### PR TITLE
Accessrries

### DIFF
--- a/app/(admin)/productcreate/page.tsx
+++ b/app/(admin)/productcreate/page.tsx
@@ -206,16 +206,20 @@ export default function ProductCreate() {
   };
 
   const handleSave = async () => {
+    // Modified validation logic to handle accessories category
     if (
       !formData.productName ||
       !formData.category ||
       !formData.regularPrice ||
       !formData.subCategory ||
-      !(formData.sizes.length > 0) ||
+      // Only validate sizes for non-accessories categories
+      (formData.category !== "Accessories" && !(formData.sizes.length > 0)) ||
       formData.gallery.length === 0
     ) {
       alert(
-        "Please fill in all required fields (Product Name, Sizes, Category, Sub-Category, Regular Price) and add at least one product image with color!"
+        `Please fill in all required fields (Product Name, ${
+          formData.category !== "Accessories" ? "Sizes, " : ""
+        }Category, Sub-Category, Regular Price) and add at least one product image with color!`
       );
       return;
     }
@@ -621,34 +625,37 @@ export default function ProductCreate() {
                 onRemoveImage={handleRemoveImage}
                 onUpdateColor={handleUpdateColor}
               />
-              <div>
-                <label className="block text-sm font-medium mb-2">
-                  Size <span className="text-red-500">*</span>
-                </label>
-                <div className="flex flex-wrap gap-2">
-                  {["NS", "XS", "S", "M", "L", "XL", "2XL", "3XL"].map(
-                    (size) => (
-                      <label key={size} className="flex items-center">
-                        <input
-                          type="checkbox"
-                          checked={formData.sizes.includes(size)}
-                          onChange={() => handleSizeChange(size)}
-                          className="hidden"
-                        />
-                        <span
-                          className={`inline-flex items-center justify-center px-4 py-3 text-sm font-medium rounded-md border border-gray-300 cursor-pointer ${
-                            formData.sizes.includes(size)
-                              ? "bg-gray-500 text-white"
-                              : "bg-gray-300"
-                          }`}
-                        >
-                          {size}
-                        </span>
-                      </label>
-                    )
-                  )}
+              {/* Show size selector only when not in Accessories category */}
+              {formData.category !== "Accessories" && (
+                <div>
+                  <label className="block text-sm font-medium mb-2">
+                    Size <span className="text-red-500">*</span>
+                  </label>
+                  <div className="flex flex-wrap gap-2">
+                    {["NS", "XS", "S", "M", "L", "XL", "2XL", "3XL"].map(
+                      (size) => (
+                        <label key={size} className="flex items-center">
+                          <input
+                            type="checkbox"
+                            checked={formData.sizes.includes(size)}
+                            onChange={() => handleSizeChange(size)}
+                            className="hidden"
+                          />
+                          <span
+                            className={`inline-flex items-center justify-center px-4 py-3 text-sm font-medium rounded-md border border-gray-300 cursor-pointer ${
+                              formData.sizes.includes(size)
+                                ? "bg-gray-500 text-white"
+                                : "bg-gray-300"
+                            }`}
+                          >
+                            {size}
+                          </span>
+                        </label>
+                      )
+                    )}
+                  </div>
                 </div>
-              </div>
+              )}
             </div>
           </div>
           <div className="flex justify-end gap-4 mt-6">

--- a/app/api/products/[id]/route.tsx
+++ b/app/api/products/[id]/route.tsx
@@ -111,19 +111,36 @@ export async function PUT(
       })
     );
     
+    // Create an update object that handles accessories appropriately
+    const updateData = {
+      productName: body.productName,
+      description: body.description,
+      category: body.category,
+      subCategory: body.subCategory,
+      regularPrice: Number(body.regularPrice),
+      tag: body.tag,
+      // For accessories, we may have an empty sizes array
+      sizes: body.sizes || [],
+      gallery: processedGallery,
+      
+      // Add occasion-related fields if they're provided
+      ...(body.occasions ? { occasions: body.occasions } : {}),
+      ...(body.style ? { style: body.style } : {}),
+      ...(body.season ? { season: body.season } : {}),
+      
+      // Only include fit/sizing fields if not an accessory
+      ...(body.category !== "Accessories" ? {
+        fitType: body.fitType,
+        sizingTrend: body.sizingTrend,
+        sizingNotes: body.sizingNotes,
+        ...(body.sizeChart && Object.keys(body.sizeChart).length > 0 ? { sizeChart: body.sizeChart } : {})
+      } : {})
+    };
+    
     // Update product with processed gallery
     const updatedProduct = await Product.findByIdAndUpdate(
       id, 
-      {
-        productName: body.productName,
-        description: body.description,
-        category: body.category,
-        subCategory: body.subCategory,
-        regularPrice: Number(body.regularPrice),
-        tag: body.tag,
-        sizes: body.sizes,
-        gallery: processedGallery
-      }, 
+      updateData, 
       { new: true }
     );
     

--- a/app/api/products/route.tsx
+++ b/app/api/products/route.tsx
@@ -151,6 +151,13 @@ export async function POST(request: Request) {
       occasions: body.occasions || [],
       style: body.style || [],
       season: body.season || [],
+      
+      // Add fitType and sizing info - these will be relevant for clothing but not accessories
+      fitType: body.fitType,
+      sizingTrend: body.sizingTrend,
+      sizingNotes: body.sizingNotes,
+      // Only add sizeChart if it's defined
+      ...(body.sizeChart && Object.keys(body.sizeChart).length > 0 ? { sizeChart: body.sizeChart } : {})
     });
     
     await newProduct.save();
@@ -162,11 +169,13 @@ export async function POST(request: Request) {
       stock: 0, // Initialize with zero stock
       status: 'Newly Added', // Set initial status
       image: processedGallery.length > 0 ? processedGallery[0].src : '',
-      // Initialize size stock with zeros
-      sizeStock: body.sizes.reduce((acc: any, size: string) => {
-        acc[size] = 0;
-        return acc;
-      }, {})
+      // Initialize size stock with zeros - only for non-accessories or if sizes are provided
+      sizeStock: body.sizes && body.sizes.length > 0 ? 
+        body.sizes.reduce((acc: any, size: string) => {
+          acc[size] = 0;
+          return acc;
+        }, {}) : 
+        { default: 0 } // Use a default stock counter for accessories
     });
     
     await newInventory.save();

--- a/app/components/ProductCard.tsx
+++ b/app/components/ProductCard.tsx
@@ -98,8 +98,9 @@ const ProductCard = ({ product, hideWishlist }: ProductCardProps) => {
     e.preventDefault();
     e.stopPropagation();
     
-    // Don't allow adding to cart without selecting a size if product has sizes
-    if (productWithDefaults.sizes.length > 0 && !selectedSize) {
+    // Only check for size selection if the product is not in Accessories category and has sizes
+    const isAccessory = product.category === "Accessories";
+    if (!isAccessory && productWithDefaults.sizes.length > 0 && !selectedSize) {
       toast.error("Please select a size");
       return;
     }
@@ -113,7 +114,7 @@ const ProductCard = ({ product, hideWishlist }: ProductCardProps) => {
       name: product.name,
       price: product.price,
       image: colorImage || product.image,
-      size: selectedSize || undefined,
+      size: !isAccessory ? selectedSize || undefined : undefined,
       color: selectedColor || undefined
     }, false); // Set second parameter to false
     
@@ -270,8 +271,8 @@ const ProductCard = ({ product, hideWishlist }: ProductCardProps) => {
         </div>
       )}
       
-      {/* Sizes with selection indicator */}
-      {productWithDefaults.sizes.length > 0 && (
+      {/* Sizes with selection indicator - only show for non-accessories */}
+      {product.category !== "Accessories" && productWithDefaults.sizes.length > 0 && (
         <div className="flex gap-2 mt-2">
           {productWithDefaults.sizes.slice(0, 5).map((size, index) => (
             <button

--- a/app/components/ProductInformation.tsx
+++ b/app/components/ProductInformation.tsx
@@ -13,6 +13,7 @@ interface ProductInformationProps {
     images: string[]; // Use images array instead of colors array
     sizes: string[];
     rating: number;
+    category?: string; // Add category property to check if it's an accessory
   };
   quantity: number;
   updateQuantity: (value: number) => void;
@@ -31,6 +32,9 @@ const ProductInformation: React.FC<ProductInformationProps> = ({
 }) => {
   // Add state for size guide modal
   const [isSizeGuideOpen, setIsSizeGuideOpen] = useState(false);
+  
+  // Check if product is an accessory
+  const isAccessory = product.category === "Accessories";
 
   // Generate stars for rating
   const renderRatingStars = () => {
@@ -126,8 +130,8 @@ const ProductInformation: React.FC<ProductInformationProps> = ({
         </div>
       )}
       
-      {/* Sizes */}
-      {product.sizes && product.sizes.length > 0 && (
+      {/* Sizes - Only show for non-accessories */}
+      {!isAccessory && product.sizes && product.sizes.length > 0 && (
         <div className="mb-6">
           <div className="flex justify-between items-center mb-2">
             <h2 className="text-sm font-medium">Size</h2>
@@ -177,12 +181,14 @@ const ProductInformation: React.FC<ProductInformationProps> = ({
         </div>
       </div>
 
-      {/* Size Guide Modal */}
-      <SizeGuideModal 
-        isOpen={isSizeGuideOpen} 
-        onClose={() => setIsSizeGuideOpen(false)} 
-        category="apparel" 
-      />
+      {/* Size Guide Modal - only show for non-accessories */}
+      {!isAccessory && (
+        <SizeGuideModal 
+          isOpen={isSizeGuideOpen} 
+          onClose={() => setIsSizeGuideOpen(false)} 
+          category="apparel" 
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
This pull request includes several changes to handle the "Accessories" category differently in the product creation and update processes. The changes ensure that size-related fields are only validated and displayed for non-accessories categories.

### Product Creation and Update Logic:

* Modified validation logic in `ProductCreate` to handle accessories category by skipping size validation for accessories.
* Updated the product creation form to conditionally display the size selector only for non-accessories categories. [[1]](diffhunk://#diff-8838578539c2ad8abb73f5ff1dd2a05e5f8778e95d8b6b618875798baaed0929R628-R629) [[2]](diffhunk://#diff-8838578539c2ad8abb73f5ff1dd2a05e5f8778e95d8b6b618875798baaed0929R658)

### API Changes:

* Adjusted the `PUT` method in `route.tsx` to handle accessories appropriately by creating an update object that conditionally includes size-related fields. ([app/api/products/[id]/route.tsxL114-R143](diffhunk://#diff-0c446ed4e11e2c560693312802d7e525be96a76bee7fe6d87029ac07b8f43e9fL114-R143))
* Modified the `POST` method in `route.tsx` to include fitType and sizing info only for non-accessories and initialize size stock conditionally. [[1]](diffhunk://#diff-9b96d6f39d8b038e442e28660b9760a2d22e6e3a31b83aedfa1df457f3911498R154-R160) [[2]](diffhunk://#diff-9b96d6f39d8b038e442e28660b9760a2d22e6e3a31b83aedfa1df457f3911498L165-R178)

### Component Updates:

* Updated `ProductCard` to ensure size selection checks and size display are only applied to non-accessories. [[1]](diffhunk://#diff-1abab1a04578cfca88ee7a312a96dfe252142257787ec61f23ebbd7e02a67e70L101-R103) [[2]](diffhunk://#diff-1abab1a04578cfca88ee7a312a96dfe252142257787ec61f23ebbd7e02a67e70L116-R117) [[3]](diffhunk://#diff-1abab1a04578cfca88ee7a312a96dfe252142257787ec61f23ebbd7e02a67e70L273-R275)
* Added a category property to `ProductInformation` and conditionally rendered size-related elements only for non-accessories. [[1]](diffhunk://#diff-21fb2ac86a123a8201ad602fbd261fa852102d0c0015ea8ca5fed530723da0abR16) [[2]](diffhunk://#diff-21fb2ac86a123a8201ad602fbd261fa852102d0c0015ea8ca5fed530723da0abR36-R38) [[3]](diffhunk://#diff-21fb2ac86a123a8201ad602fbd261fa852102d0c0015ea8ca5fed530723da0abL129-R134) [[4]](diffhunk://#diff-21fb2ac86a123a8201ad602fbd261fa852102d0c0015ea8ca5fed530723da0abL180-R191)