### PR TITLE
Disable ESLint during builds and update ESLint configuration to ignor…

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,9 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    ignores: ['**/*'], // Ignore all files to disable ESLint
+  }
 ];
 
 export default eslintConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // Disable ESLint during builds
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+  
   images: {
     domains: [
       'res.cloudinary.com',


### PR DESCRIPTION
This pull request includes changes to disable ESLint for the project. The most important updates involve modifying the ESLint configuration and disabling ESLint checks during builds in the Next.js configuration.

### ESLint configuration updates:

* [`eslint.config.mjs`](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2L13-R15): Replaced the `compat.extends` configuration with a new rule that ignores all files, effectively disabling ESLint.

### Next.js configuration updates:

* [`next.config.ts`](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bR4-R8): Added an `eslint` property to the Next.js configuration to disable ESLint checks during builds by setting `ignoreDuringBuilds` to `true`.…e all files